### PR TITLE
Add reflecting_inner BC

### DIFF
--- a/src/atmo.hpp
+++ b/src/atmo.hpp
@@ -83,6 +83,6 @@ struct atmo::run_config
     /** Physics setup */
     double outer_radius      = 10.0;
     double noise             = 1e-3;
-    double heating_rate       = 0.1;
-    double cooling_rate       = 0.1;
+    double heating_rate       = 0.25;
+    double cooling_rate       = 0.05;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -556,7 +556,7 @@ struct boundary_value
     {
         switch (edge)
         {
-            case PatchBoundary::il: return fixed_inner(patch);
+            case PatchBoundary::il: return reflecting_inner(patch);
             case PatchBoundary::ir: return zero_gradient_outer(patch);
             case PatchBoundary::jl: return nd::array<double, 3>();
             case PatchBoundary::jr: return nd::array<double, 3>();
@@ -583,6 +583,30 @@ struct boundary_value
         U.select(_, _, 2) = P[2];
         U.select(_, _, 3) = P[3];
         U.select(_, _, 4) = P[4];
+        return U;
+    }
+
+    nd::array<double, 3> reflecting_inner(const nd::array<double, 3>& patch) const
+    {
+        auto _ = nd::axis::all();
+        auto U = nd::array<double, 3>(2, patch.shape(1), 5);
+        auto non_const_patch = patch;
+
+        U.select(0, _, 0) = patch.select(1, _, 0);
+        U.select(1, _, 0) = patch.select(0, _, 0);
+
+        U.select(0, _, 1) = non_const_patch.select(1, _, 1) * -1.0;
+        U.select(1, _, 1) = non_const_patch.select(0, _, 1) * -1.0;
+
+        U.select(0, _, 2) = patch.select(1, _, 2);
+        U.select(1, _, 2) = patch.select(0, _, 2);
+
+        U.select(0, _, 3) = patch.select(1, _, 3);
+        U.select(1, _, 3) = patch.select(0, _, 3);
+
+        U.select(0, _, 4) = patch.select(1, _, 4);
+        U.select(1, _, 4) = patch.select(0, _, 4);
+
         return U;
     }
 };


### PR DESCRIPTION
Hi Jonathan,

I'm a bit unsure of the naming convention of the ghostcells in direction i: line 588-611 in main.cpp. Also, I'm trying to use the ndarray operator * to flip the sign of v(r) but the compiler keeps complaining due to it being a const_ref object. 

The sim keeps crashing, if the reflecting BC is implemented correctly, I can start working on a fix for that. Let me know thanks!

Best,
Andrew